### PR TITLE
better use the repository field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "rspotd"
 version = "0.5.0"
 edition = "2021"
 description = "Generate ARRIS/CommScope Password of the Day for modems"
-homepage = "https://github.com/SnailShea/rspotd"
+repository = "https://github.com/SnailShea/rspotd"
 license = "MIT OR Apache-2.0"
 keywords = ["arris", "commscope", "modem", "docsis", "potd"]
 


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it
See also [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field)
